### PR TITLE
Fix test flakiness due to undeterministic order of list of strings

### DIFF
--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/RerunFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/RerunFormatterTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
 
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static io.cucumber.core.plugin.Bytes.bytes;
 import static java.util.Arrays.asList;
@@ -20,6 +23,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RerunFormatterTest {
 
@@ -245,9 +249,14 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out,
-            bytes(
-                equalToCompressingWhiteSpace("classpath:path/first.feature:2\nclasspath:path/second.feature:2\n")));
+        String outString = out.toString();
+        List<String> classPaths = Arrays.asList(outString.split("\\n"));
+        classPaths.sort(null);
+
+        List<String> extepedClassPaths = new ArrayList<>(
+            Arrays.asList("classpath:path/first.feature:2", "classpath:path/second.feature:2"));
+
+        assertEquals(classPaths, extepedClassPaths);
     }
 
 }


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?



Fixed the implementation of flaky should_one_entry_for_each_failing_feature() test. Previous implementation results in non deterministic ordering of strings which may occasionally fail between multiple runs, as explained in the next section.

#### Proposed fix
- Convert the output `ByteArrayOutputStream` into strings and subsequently to `List` of strings (strings are separated by newline character).
- Sort this list of strings. Sorting will maintain the ordering of strings between different runs.
- Compare sorted list with expected list of strings, which always passes. 

### ⚡️ What's your motivation? 

The implementation of io.cucumber.core.plugin.RerunFormatterTest#should_one_entry_for_each_failing_feature was flaky. The ordering of strings `"classpath:path/first.feature:2"` and `"classpath:path/second.feature:2"` separated with newline changes between different runs due to the underlying implementation of cucumber Runtime builder. Thus, after compressing the string it may result in one of the following string - 
- `"classpath:path/first.feature:2\nclasspath:path/second.feature:2\n"`
- `"classpath:path/second.feature:2\nclasspath:path/first.feature:2\n"`

However, in the previous implementation we were always comparing it with `"classpath:path/first.feature:2\nclasspath:path/second.feature:2\n"`, which is not always true.

#### Steps to reproduce flaky tests
- Build the project using this command - 
  - `./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true`
- The flakiness of this test was verified using [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. NonDex explores different behaviors of under-determined APIs and reports test failures under different explored behaviors
- Run following command to run nonDex for targeted test
  - `./mvnw edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl cucumber-core -Dtest=io.cucumber.core.plugin.RerunFormatterTest#should_one_entry_for_each_failing_feature -DnondexRuns=10`
  - You may change the number of runs with the -DnondexRuns option
- You will observe that atleast one run of the test fails, along with the reason of failure - 
  - `_[ERROR]   RerunFormatterTest.should_one_entry_for_each_failing_feature:248 Expected: is a string equal to "classpath:path/first.feature:2\nclasspath:path/second.feature:2\n" compressing white space but: was "classpath:path/second.feature:2\nclasspath:path/first.feature:2\n"_`
  - We can observe that the ordering of strings separated with newline character varies between runs, which causes the flakiness.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->


- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
